### PR TITLE
feat: reverse claim on user page

### DIFF
--- a/apps/web/src/routes/users/$userId.tsx
+++ b/apps/web/src/routes/users/$userId.tsx
@@ -93,6 +93,15 @@ function UserDetailPage() {
 		onSuccess: () => queryClient.invalidateQueries(),
 	});
 
+	const reverseClaimMutation = useMutation({
+		mutationFn: (voucherId: Id<"vouchers">) =>
+			convex.mutation(api.admin.reverseClaim, {
+				token: token!,
+				voucherId,
+			}),
+		onSuccess: () => queryClient.invalidateQueries(),
+	});
+
 	if (isLoading) {
 		return <div className="text-muted-foreground">Loading user details...</div>;
 	}
@@ -248,7 +257,9 @@ function UserDetailPage() {
 																		? "bg-red-100 text-red-800"
 																		: tx.type === "admin_expiry_deduction"
 																			? "bg-rose-100 text-rose-800"
-																			: "bg-amber-100 text-amber-800"
+																			: tx.type === "claim_reversed"
+																				? "bg-teal-100 text-teal-800"
+																				: "bg-amber-100 text-amber-800"
 												}`}
 											>
 												{tx.type.replace(/_/g, " ")}
@@ -435,6 +446,18 @@ function UserDetailPage() {
 											</Link>
 										</div>
 									)}
+									<div className="mt-3">
+										<Button
+											size="sm"
+											variant="outline"
+											onClick={() =>
+												reverseClaimMutation.mutate(voucher._id as Id<"vouchers">)
+											}
+											disabled={reverseClaimMutation.isPending}
+										>
+											Make Available
+										</Button>
+									</div>
 								</div>
 							</div>
 						))}

--- a/packages/backend/convex/admin.ts
+++ b/packages/backend/convex/admin.ts
@@ -7,7 +7,7 @@ import {
 import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import type { ActionCtx, QueryCtx } from "./_generated/server";
-import { MIN_COINS, UPLOAD_REWARDS } from "./constants";
+import { MIN_COINS, UPLOAD_REWARDS, CLAIM_COSTS } from "./constants";
 import {
 	action,
 	internalAction,
@@ -720,6 +720,62 @@ export const expireVoucherAndDeductCoins = adminMutation({
 			success: true,
 			deductedAmount: deductionAmount,
 			newBalance: newCoins,
+		};
+	},
+});
+
+export const reverseClaim = adminMutation({
+	args: {
+		voucherId: v.id("vouchers"),
+	},
+	handler: async (ctx, { voucherId }) => {
+		const voucher = await ctx.db.get(voucherId);
+		if (!voucher) {
+			throw new Error("Voucher not found");
+		}
+
+		if (voucher.status !== "claimed") {
+			throw new Error("Voucher must be claimed to reverse");
+		}
+
+		if (!voucher.claimerId) {
+			throw new Error("Voucher has no claimer");
+		}
+
+		const claimer = await ctx.db.get(voucher.claimerId);
+		if (!claimer) {
+			throw new Error("Claimer not found");
+		}
+
+		const refundAmount = CLAIM_COSTS[voucher.type] ?? 0;
+		const now = Date.now();
+
+		// Reverse the claim on the voucher
+		await ctx.db.patch(voucherId, {
+			status: "available",
+			claimerId: undefined,
+			claimedAt: undefined,
+		});
+
+		// Refund coins to claimer
+		await ctx.db.patch(voucher.claimerId, {
+			coins: claimer.coins + refundAmount,
+			claimCount: Math.max(0, (claimer.claimCount || 0) - 1),
+		});
+
+		// Record the reversal transaction
+		await ctx.db.insert("transactions", {
+			userId: voucher.claimerId,
+			type: "claim_reversed",
+			amount: refundAmount,
+			voucherId,
+			createdAt: now,
+		});
+
+		return {
+			success: true,
+			refundAmount,
+			newClaimerBalance: claimer.coins + refundAmount,
 		};
 	},
 });

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -110,6 +110,7 @@ export default defineSchema({
 			v.literal("uploader_refund"),
 			v.literal("uploader_denied"),
 			v.literal("admin_expiry_deduction"),
+			v.literal("claim_reversed"),
 		),
 		amount: v.number(),
 		voucherId: v.optional(v.id("vouchers")),


### PR DESCRIPTION
Adds a 'Make Available' button to claimed vouchers on the individual user page.

**What this does:**
- Sets voucher status back to \available\
- Removes claimedAt and claimerId
- Refunds claimer's coins based on voucher type
- Decrements claimer's claimCount
- Records a new \claim_reversed\ transaction

**Files changed:**
- \convex/schema.ts\ — new transaction type
- \convex/admin.ts\ — reverseClaim mutation
- \routes/users/\.tsx\ — UI button + transaction badge styling