### PR TITLE
Add dev worker for mini app testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # ⚠️ IMPORTANT: NEVER DEPLOY UNLESS EXPLICITLY ASKED
 
-Do not run `bun run deploy:all`, `bun run deploy:web`, `bun run deploy:server`, or `bunx convex deploy` unless the user explicitly asks you to deploy. Always commit and push first, then wait for the user to decide when to deploy.
+Do not run `bun run deploy:all`, `bun run deploy:web`, `bun run deploy:web:dev`, `bun run deploy:dev`, `bun run deploy:server`, or `bunx convex deploy` unless the user explicitly asks you to deploy. Always commit and push first, then wait for the user to decide when to deploy.
 
 ## Never Commit or Push Without Explicit Permission
 
@@ -50,6 +50,9 @@ The following `bun run` scripts are available from the root directory:
 *   `bun run dev:web`: Starts only the web frontend application in development mode.
 *   `bun run dev:server`: Starts only the Convex backend server in development mode.
 *   `bun run dev:setup`: Sets up and configures the Convex project.
+*   `bun run deploy:web`: Deploy production Cloudflare Worker.
+*   `bun run deploy:web:dev`: Deploy dev Cloudflare Worker (`dev.openvouchers.org`, always dev Convex).
+*   `bun run deploy:dev`: Deploy dev worker + register dev bot commands.
 
 ## Development Conventions
 

--- a/README.md
+++ b/README.md
@@ -16,27 +16,94 @@ Then, run the development server:
 ```bash
 bun run dev
 ```
-This will start
+
+This will start:
+
 - Admin dashboard at [http://localhost:3001](http://localhost:3001)
-- Convex backend for the bot.
+- Convex backend for the bot (`convex dev` syncs the **development** deployment)
 
 ## Project Structure
 
 ```
 open-voucher/
 ├── apps/
-│   ├── web/         # Frontend application (React + TanStack Start)
+│   └── web/         # Frontend (React + TanStack Start) on Cloudflare Workers
 ├── packages/
-│   ├── backend/     # Convex backend functions and schema
+│   └── backend/     # Convex backend functions and schema
 ```
 
-## Available pacakges/backend
+## Available Scripts
 
-- `bun run dev`: Start all applications in development mode
-- `bun run build`: Build all applications
-- `bun run dev:web`: Start only the web application
-- `bun run dev:setup`: Setup and configure your Convex project
-- `bun run check-types`: Check TypeScript types across all apps
+| Script | Description |
+|--------|-------------|
+| `bun run dev` | Start web + Convex dev server |
+| `bun run dev:web` | Web only (localhost:3001) |
+| `bun run dev:server` | Convex dev only (`convex dev`) |
+| `bun run build` | Production build (all packages) |
+| `bun run check-types` | TypeScript across the monorepo |
+| `bun run deploy:web` | Deploy **production** web worker |
+| `bun run deploy:web:dev` | Deploy **dev** web worker (mini app testing) |
+| `bun run deploy:backend` | Deploy Convex **production** + register prod bot commands |
+| `bun run deploy:backend:dev` | Register bot commands on **dev** Convex |
+| `bun run deploy:dev` | Deploy dev worker + register dev bot commands |
+| `bun run deploy:all` | Production web + backend deploy |
+
+## Deployments
+
+| Environment | Web | Convex | Telegram |
+|-------------|-----|--------|----------|
+| **Local** | `localhost:3001` | Dev deployment via `convex dev` | Optional dev bot |
+| **Dev** | `dev.openvouchers.org` (CF Worker `open-voucher-web-dev`) | Dev deployment | Separate **dev bot** (Doppler `dev`) |
+| **Production** | `openvouchers.org` (CF Worker `open-voucher-web`) | Production deployment | Production bot (Doppler `prd`) |
+
+The dev web worker is built with `VITE_DEPLOYMENT=dev` and always talks to the dev Convex deployment. The admin environment switcher is hidden on that host.
+
+**Convex note:** `convex deploy` updates the **production** deployment. The **development** deployment is updated by running `convex dev` (included in `bun run dev` / `bun run dev:server`). Keep `convex dev` running while testing the mini app against dev Convex.
+
+### Dev mini app (first-time setup)
+
+1. **Cloudflare** — Deploy the dev worker once, then attach the custom domain:
+   ```bash
+   bun run deploy:web:dev
+   ```
+   In the Cloudflare dashboard: **Workers & Pages** → `open-voucher-web-dev` → **Settings** → **Domains & Routes** → add `dev.openvouchers.org`.
+
+2. **Doppler + Convex + webhook** — Use a separate dev bot token:
+   ```bash
+   ./manageWebhooks.sh dev
+   ```
+   This sets dev Convex env vars (including `MINI_APP_URL=https://dev.openvouchers.org/app`).
+
+3. **BotFather** — On the **dev** bot, register the mini app URL `https://dev.openvouchers.org/app`.
+
+4. **Bot commands** — After backend or command changes:
+   ```bash
+   bun run deploy:backend:dev
+   ```
+   Or as part of a full dev frontend deploy:
+   ```bash
+   bun run deploy:dev
+   ```
+
+### Day-to-day mini app development
+
+```bash
+# Terminal 1 — sync functions/schema to dev Convex
+bun run dev:server
+
+# Terminal 2 — local web (optional)
+bun run dev:web
+
+# When testing in Telegram on dev.openvouchers.org
+bun run deploy:web:dev
+```
+
+### Production deploy
+
+```bash
+./manageWebhooks.sh prd   # when webhook or Convex secrets change
+bun run deploy:all        # production web + convex deploy + prod commands
+```
 
 ## Environment Setup
 
@@ -44,15 +111,15 @@ Secrets are managed in [Doppler](https://www.doppler.com/) and deployed to Conve
 
 ### Prerequisites
 
-1. **Install Doppler CLI** - See [Doppler CLI documentation](https://docs.doppler.com/docs/install-cli)
+1. **Install Doppler CLI** — See [Doppler CLI documentation](https://docs.doppler.com/docs/install-cli)
 2. **Login to Doppler:**
    ```bash
    doppler login
    doppler setup
    ```
 3. A Google AI API key from [Google AI Studio](https://aistudio.google.com/app/apikey)
-4. A telegram bot token from [@BotFather](https://t.me/botfather)
-5. A convex account and project.
+4. Telegram bot token(s) from [@BotFather](https://t.me/botfather) — use a **separate bot** for dev and production
+5. A Convex account and project
 
 ### Required Secrets (in Doppler)
 
@@ -64,12 +131,14 @@ Secrets are managed in [Doppler](https://www.doppler.com/) and deployed to Conve
 | `ADMIN_PASSWORD` | Admin panel access | Set your own secure password |
 | `CONVEX_WEBHOOK_URL` | Your Convex webhook URL | From Convex dashboard |
 
+`MINI_APP_URL` is set automatically by `manageWebhooks.sh` (`https://dev.openvouchers.org/app` for dev, `https://openvouchers.org/app` for production).
+
 ### Setup Script
 
 Run the webhook management script to configure everything at once:
 
 ```bash
-# For development
+# For development (dev bot + dev Convex)
 ./manageWebhooks.sh dev
 
 # For production
@@ -77,31 +146,30 @@ Run the webhook management script to configure everything at once:
 ```
 
 This script will:
+
 - Fetch secrets from Doppler
 - Delete and set the Telegram webhook
-- Configure all environment variables in Convex
+- Configure environment variables in Convex (tokens, `ENVIRONMENT`, `MINI_APP_URL`, etc.)
 
 ### Register Telegram Bot Commands
 
-After initial setup, register the bot commands so users see suggestions when typing `/`:
-
-```bash
-bunx convex run telegram:registerBotCommands
-```
+| Environment | Command |
+|-------------|---------|
+| Dev | `bun run deploy:backend:dev` or `cd packages/backend && bunx convex run telegram:registerBotCommands` |
+| Production | `bun run deploy:backend` (runs after `convex deploy`) |
 
 This enables the command menu in Telegram with:
-- `/help` - Show help menu
-- `/balance` - Check your coin balance
-- `/faq` - Frequently asked questions
-- `/feedback` - Send feedback
-- `/donate` - Support the project
+
+- `/help` — Show help menu
+- `/balance` — Check your coin balance
+- `/donate` — Support the project
 
 ### Sample/Test Voucher Setup
 
 To set up the sample voucher image shown to users:
 
 1. Go to your [Convex Dashboard](https://dashboard.convex.dev)
-2. Upload `config/sample-voucher.png` and `config/test-voucher.png` to the Storage. Note the storage IDs.
+2. Upload `config/sample-voucher.png` and `config/test-voucher.png` to Storage. Note the storage IDs.
 3. Navigate to: **Functions**
 4. Run the function: `settings.setSetting`
 5. Arguments: `{"key": "sample-voucher-image", "value": "<storage-id>"}`
@@ -125,6 +193,7 @@ Daily backups of Convex table data and file storage (voucher images) can be run 
 ```
 
 Backups are saved to `~/backups/open-voucher/` with human-readable names like:
+
 - `open-voucher-backup-dev-2026-05-04.zip`
 - `open-voucher-backup-prd-2026-05-04.zip`
 
@@ -145,9 +214,11 @@ Add to your crontab (`crontab -e`). Make sure `PATH` includes your Node.js binar
 ## Ban Rules
 
 ### Reporter Ban
+
 If a user reports **3 or more of their last 5 claims**, they get banned for abuse.
 
 ### Uploader Ban
+
 If **3 or more of an uploader's last 5 uploads** are reported as not working, they get banned. Reports from banned users are ignored to prevent retaliatory bans.
 
 ## Rate Limits
@@ -158,8 +229,8 @@ If **3 or more of an uploader's last 5 uploads** are reported as not working, th
 | Uploads | 10 per 24 hours |
 | Claims | 5 per 24 hours |
 
-
 ## Todo
+
 - [ ] seed dev data - https://docs.convex.dev/database/import-export/import
 - [ ] update landing page with faq
 - [ ] cron job to clean up old vouchers and failed uploads

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,1 +1,5 @@
+# Optional override; prod/dev URLs are defined in src/lib/convexConfig.ts
 VITE_CONVEX_URL=
+
+# Set automatically by `bun run build:dev` / `deploy:dev` (locks the worker to dev Convex)
+# VITE_DEPLOYMENT=dev

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,9 +4,11 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build",
+		"build:dev": "VITE_DEPLOYMENT=dev vite build",
 		"dev": "vite dev --port=3001",
 		"preview": "bun run build && vite preview",
 		"deploy": "bun run build && wrangler deploy",
+		"deploy:dev": "bun run build:dev && wrangler deploy --config dist/server/wrangler.json --name open-voucher-web-dev",
 		"cf-typegen": "wrangler types",
 		"check-types": "tsc --noEmit"
 	},

--- a/apps/web/src/components/EnvironmentDropdown.tsx
+++ b/apps/web/src/components/EnvironmentDropdown.tsx
@@ -10,8 +10,32 @@ import { ChevronDownIcon } from "lucide-react";
 
 export type Deployment = "dev" | "prod";
 
+const DEV_HOSTNAME = "dev.openvouchers.org";
+
+/** Dev Cloudflare Worker build — always uses dev Convex; no env switcher. */
+export function isDeploymentLocked(): boolean {
+	if (import.meta.env.VITE_DEPLOYMENT === "dev") {
+		return true;
+	}
+	if (
+		typeof window !== "undefined" &&
+		window.location.hostname === DEV_HOSTNAME
+	) {
+		return true;
+	}
+	return false;
+}
+
 export function getDeployment(): Deployment {
-	if (typeof window === "undefined") return "prod";
+	if (import.meta.env.VITE_DEPLOYMENT === "dev") {
+		return "dev";
+	}
+	if (typeof window === "undefined") {
+		return "prod";
+	}
+	if (window.location.hostname === DEV_HOSTNAME) {
+		return "dev";
+	}
 	return (localStorage.getItem("convex-deployment") as Deployment) || "prod";
 }
 

--- a/apps/web/src/components/NavigationLayout.tsx
+++ b/apps/web/src/components/NavigationLayout.tsx
@@ -1,6 +1,9 @@
 import { Link } from "@tanstack/react-router";
 import { LogOut } from "lucide-react";
-import { EnvironmentDropdown } from "@/components/EnvironmentDropdown";
+import {
+	EnvironmentDropdown,
+	isDeploymentLocked,
+} from "@/components/EnvironmentDropdown";
 import { Button } from "@/components/ui/button";
 import { useAdminAuth } from "@/hooks/useAdminAuth";
 
@@ -77,7 +80,7 @@ export function NavigationLayout() {
 					<LogOut className="mr-2 h-4 w-4" />
 					Logout
 				</Button>
-				<EnvironmentDropdown />
+				{!isDeploymentLocked() && <EnvironmentDropdown />}
 			</div>
 		</div>
 	);

--- a/manageWebhooks.sh
+++ b/manageWebhooks.sh
@@ -15,6 +15,8 @@
 #   - TELEGRAM_WEBHOOK_SECRET
 #   - GOOGLE_GENERATIVE_AI_API_KEY
 #   - ADMIN_PASSWORD
+#
+# MINI_APP_URL is set automatically per environment (see set_convex_vars).
 
 # Check if environment argument is provided
 ENV=${1:-dev}
@@ -186,6 +188,14 @@ set_convex_vars() {
     # Set Admin password
     echo "Setting ADMIN_PASSWORD..."
     (cd packages/backend && npx convex env set ADMIN_PASSWORD "$admin_password" $prod_flag)
+
+    # Mini App URL for Telegram web_app buttons
+    local mini_app_url="https://dev.openvouchers.org/app"
+    if [ "$env_name" = "prd" ]; then
+        mini_app_url="https://openvouchers.org/app"
+    fi
+    echo "Setting MINI_APP_URL to ${mini_app_url}..."
+    (cd packages/backend && npx convex env set MINI_APP_URL "$mini_app_url" $prod_flag)
     echo ""
 }
 

--- a/package.json
+++ b/package.json
@@ -20,8 +20,11 @@
 		"dev:setup": "turbo -F @open-voucher/backend dev:setup",
 		"format": "biome format --write .",
 		"format:check": "biome format .",
-		"deploy:web": "turbo -F web deploy",
+		"deploy:web": "bun run -F web deploy",
+		"deploy:web:dev": "bun run -F web deploy:dev",
 		"deploy:backend": "turbo -F @open-voucher/backend deploy && bun run -F @open-voucher/backend register-commands",
+		"deploy:backend:dev": "bun run -F @open-voucher/backend register-commands:dev",
+		"deploy:dev": "bun run deploy:web:dev && bun run deploy:backend:dev",
 		"deploy:all": "turbo deploy"
 	},
 	"dependencies": {},

--- a/packages/backend/convex/http.ts
+++ b/packages/backend/convex/http.ts
@@ -7,6 +7,7 @@ const http = httpRouter();
 
 const ALLOWED_ORIGINS = [
 	"https://openvouchers.org",
+	"https://dev.openvouchers.org",
 	"http://localhost:3001",
 ];
 

--- a/packages/backend/convex/telegram.ts
+++ b/packages/backend/convex/telegram.ts
@@ -293,6 +293,10 @@ async function sendFaqMenu(chatId: string) {
 	});
 }
 
+function getMiniAppUrl(): string {
+	return process.env.MINI_APP_URL ?? "https://openvouchers.org/app";
+}
+
 async function sendAppWebAppButton(chatId: string) {
 	await sendTelegramMessage(
 		chatId,
@@ -302,7 +306,7 @@ async function sendAppWebAppButton(chatId: string) {
 				[
 					{
 						text: "📋 Open My Vouchers",
-						web_app: { url: "https://openvouchers.org/app" },
+						web_app: { url: getMiniAppUrl() },
 					},
 				],
 			],

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -10,6 +10,7 @@
 		"check-types": "tsc --noEmit",
 		"deploy": "convex deploy -y",
 		"register-commands": "convex run telegram:registerBotCommands --prod",
+		"register-commands:dev": "convex run telegram:registerBotCommands",
 		"expiring": "convex run dashboard:getExpiringVouchers --prod",
 		"expiring:dev": "convex run dashboard:getExpiringVouchers"
 	},

--- a/turbo.json
+++ b/turbo.json
@@ -24,6 +24,15 @@
 		"deploy": {
 			"dependsOn": ["build"],
 			"cache": false
+		},
+		"build:dev": {
+			"dependsOn": ["^build"],
+			"inputs": ["$TURBO_DEFAULT$", ".env*"],
+			"outputs": ["dist/**"]
+		},
+		"deploy:dev": {
+			"dependsOn": ["build:dev"],
+			"cache": false
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Adds a separate Cloudflare Worker (`open-voucher-web-dev`) for Telegram mini app testing at `dev.openvouchers.org`, always wired to the dev Convex deployment.
- New scripts: `deploy:web:dev`, `deploy:backend:dev`, `deploy:dev`; dev deploy uses the Vite build output (`dist/server/wrangler.json`) with `--name open-voucher-web-dev`.
- `manageWebhooks.sh` sets `MINI_APP_URL` per environment; CORS and bot `web_app` buttons use it.
- Dev worker hides the admin Convex env switcher; README documents setup and workflows.

## Test plan

- [ ] `bun install` then `bun run deploy:web:dev` succeeds
- [ ] Attach `dev.openvouchers.org` to `open-voucher-web-dev` in Cloudflare
- [ ] `./manageWebhooks.sh dev` sets dev Convex env including `MINI_APP_URL`
- [ ] Register `https://dev.openvouchers.org/app` on dev bot in BotFather
- [ ] `bun run deploy:backend:dev` registers commands on dev Convex
- [ ] Mini app auth works from Telegram on dev host


Made with [Cursor](https://cursor.com)